### PR TITLE
Rewrite `temp_dir` to support older `tox` versions

### DIFF
--- a/python/mandatory/tox.ini
+++ b/python/mandatory/tox.ini
@@ -36,7 +36,8 @@ setenv =
     PYTHONHASHSEED=0
     # Override the default coverage output path to tox's temp directory
     # so we don't pollute the root dir.
-    COVERAGE_FILE={temp_dir}/.coverage
+    # COVERAGE_FILE={temp_dir}/.coverage
+    COVERAGE_FILE={toxworkdir}/.tmp/.coverage
     # Override the default "PYTHON" when the "-coverage" is present.
     # This allows us to run additional steps on top of the default
     # test run, such as changing the default interpreter to "coverage run".
@@ -83,4 +84,3 @@ commands =
 
 #[testenv:yamllint]
 #commands = yamllint -c yamllintrc {toxinidir}/<PROJECT NAME GOES HERE> {toxinidir}/tests {posargs}
-


### PR DESCRIPTION
This change does not change the actual value of `temp_dir`, see

https://tox.wiki/en/3.13.2/config.html#conf-temp_dir

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>
