### PR TITLE
Ensure run-tests workflow runs coverage

### DIFF
--- a/python/github_workflows/run-tests.yaml
+++ b/python/github_workflows/run-tests.yaml
@@ -37,7 +37,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r gh-test-requirements.txt
     - name: Test with tox
-      run: tox -e py3
+      run: tox -e py3-coverage,coveragereport
     - name: Run pylint
       run: tox -e pylint
       if: matrix.python-version == '3.10'


### PR DESCRIPTION
coverage is mandatory for python now so always run in Python run-tests workflow.