### PR TITLE
pylint: increase number of attributes to 10

### DIFF
--- a/python/mandatory/pylintrc
+++ b/python/mandatory/pylintrc
@@ -21,5 +21,8 @@ ignore-long-lines=^\s+.+<?https?://\S+>?$
 #reports=yes
 score=yes
 
+[DESIGN]
+max-attributes=10
+
 [MESSAGES CONTROL]
 disable=


### PR DESCRIPTION
Pylint too-many-instance-attributes checks how many attributes are defined per class.
While this can point to a smelly code, in some cases it is a valid use (looking at sf2jira SalesforceClient class).
Default value is set to 7, this patch changes it to 10.